### PR TITLE
Update project name and `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Dossier
+# JupyterHub Dossier
 
-**Dossier** provides multi-tenant distributed [Jupyter Notebooks](https://jupyter.org/) as a Service on [Kubernetes](https://kubernetes.io/). In particular, it leverages on three existing technological stacks, integrating them in a coherent and user-friendly environment:
+Dossier is a [JupyterHub](https://jupyterhub.readthedocs.io/en/stable) extension that provides multi-tenant distributed [Jupyter Notebooks](https://jupyter.org/) as a Service on [Kubernetes](https://kubernetes.io/). In particular, it provides a Kubernetes-centric management of multi-user, distributed eScience platforms that leverage Jupyter Notebooks as their primary user interface.
 
-- [JupyterHub](https://jupyterhub.readthedocs.io/en/stable/) can spawn per-user Jupyter Notebooks on Kubernetes through the [KubeSpawner](https://github.com/jupyterhub/kubespawner) library;
-- The [Capsule](https://capsule.clastix.io/) Operator implements a multi-tenant, policy-based environment on a Kubernetes cluster, logically grouping namespaces in `Tenants` to easily manage authorization and accounting;
-- The [Jupyter-workflow](https://github.com/alpha-unito/jupyter-workflow) kernel enables Jupyter Notebooks to describe complex workflows and to execute them in a distributed fashion on hybrid HPC-Cloud infrastructures, following a Bring Your Own Device (BYOD) approach.
+The [Capsule](https://capsule.clastix.io/) platform implements a multi-tenant, policy-based environment on a Kubernetes cluster. It logically groups namespaces in `Tenants` to easily manage authorization, accounting, and resource segmentation. Dossier extends the JupyterHub [KubeSpawner](https://github.com/jupyterhub/kubespawner) library, which can spawn per-user Jupyter Notebooks on a Kubernetes cluster, to support `Tenants` and spawn user-requested Jupyter Notebooks accordingly.
+
+In this setting, a Kubernetes `Tenant` becomes the central point where system administrators can configure all aspects of Jupyter Notebooks spawning through Kubernetes `annotations`, e.g., resource requests and limits, access to GPUs and persistent volumes, Jupyter-based container images, and even custom `Spawner` classes to access remote resources (like private clouds or queue-based HPC facilities).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,11 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "dossier"
+name = "jupyterhub-dossier"
 authors = [
     {name = "Iacopo Colonnelli", email = "iacopo.colonnelli@unito.it"}
 ]
-description = "Dosser JupyterHub extension"
+description = "Dossier multi-tenant JupyterHub extension"
 readme = "README.md"
 requires-python = ">=3.8"
 license = {text = "LGPL-3.0-or-later"}


### PR DESCRIPTION
This commit updates the project name to `jupyterhub-dossier` to better remark that Dossier is actually a JupyterHub extension. In addition, it rewrites the `README.md` file to remove the reference to `Jupyter Workflow`, which is an independent library, and better describe the interaction between Dossier and Clastix Capsule.